### PR TITLE
get issue by name working

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@ import os
 import json
 from github import Github
 from pprint import pprint
+import numpy as np
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
@@ -113,6 +114,24 @@ async def issue(ctx, number=1, repoName=None): # !git issue MLH-Fellowship/githu
 	issue = repo.get_issue(number=int(number))
 	await ctx.send('> Issue Title: ' + issue.title + '\n > Issue Number: ' + str(issue.number) +'\n > Issue Link: https://github.com/' + repo.name + '/issues/' + str(issue.number))
 
+
+# GET ISSUE BY NAME
+
+@bot.command()
+async def issue_by_name(ctx, title, state, repoName=None): # !git issue_by_name title state MLH-Fellowship/github-discord-bot
+	repo=''
+	if repoName:
+		repo = git.get_repo(repoName)
+	else:
+		repo = await check_association(ctx)
+	issues = repo.get_issues(state=state)
+	for single_issue in issues:
+		if (single_issue.title == title):
+			issue = single_issue
+			await ctx.send('> Issue Title: ' + issue.title + '\n > Issue Number: ' + str(issue.number) +'\n > Issue Link: https://github.com/' + repo.name + '/issues/' + str(issue.number))
+			return
+	await ctx.send("Issue not found")
+	
 
 
 


### PR DESCRIPTION
A command was added to get an issue by its title. Run the following command from the discord channel:

!git issue_by_name title state repoName

Replace title with the title of the issue being requested and replace state with either 'open' or 'closed', and optionally you can either replace the repoName parameter with an actual repository name or remove it entirely if an associated repo name is already set in the app

Closes #26 